### PR TITLE
Adding Saturation option

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -204,6 +204,11 @@ class ImageUrlBuilder {
     return this.withOptions({crop: value})
   }
 
+  // Saturation
+  saturation(saturation: number) {
+    return this.withOptions({quality})
+  }
+  
   auto(value: AutoMode) {
     if (validAutoModes.indexOf(value) === -1) {
       throw new Error(`Invalid auto mode "${value}"`)

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export type ImageUrlBuilderOptions = Partial<SanityProjectDetails> & {
   ignoreImageParams?: boolean
   fit?: FitMode
   crop?: CropMode
+  saturation?: number
   auto?: AutoMode
 }
 
@@ -38,6 +39,7 @@ export type ImageUrlBuilderOptionsWithAliases = ImageUrlBuilderOptions & {
   'max-h'?: number
   'min-w'?: number
   'max-w'?: number
+  sat?: number
   [key: string]: any
 }
 

--- a/src/urlForImage.ts
+++ b/src/urlForImage.ts
@@ -27,6 +27,7 @@ export const SPEC_NAME_TO_URL_NAME_MAPPINGS = [
   ['quality', 'q'],
   ['fit', 'fit'],
   ['crop', 'crop'],
+  ['saturation', 'sat'],
   ['auto', 'auto'],
   ['dpr', 'dpr']
 ]


### PR DESCRIPTION
I'm unsure if what I've committed is sufficient for providing this functionality, but with the partial implementation of saturation in the asset pipeline, it seemed fitting to add it to the image builder package.

It didn't seem right to limit the saturation to a bool or some other artificial scale modifier while the key only accepts -100 as a value, as I assume the asset pipeline will roll out the full range of saturation values in the future, but I'm open to amending as you need.