### PR TITLE
Fixed focalPoint url issue

### DIFF
--- a/src/urlForImage.ts
+++ b/src/urlForImage.ts
@@ -100,7 +100,7 @@ function specToImageUrl(spec: ImageUrlBuilderOptionsWithAsset) {
 
   if (spec.focalPoint) {
     params.push(`fp-x=${spec.focalPoint.x}`)
-    params.push(`fp-x=${spec.focalPoint.y}`)
+    params.push(`fp-y=${spec.focalPoint.y}`)
   }
 
   const flip = [spec.flipHorizontal && 'h', spec.flipVertical && 'v'].filter(Boolean).join('')


### PR DESCRIPTION
There is a bug regarding the focalPoint. When it's added to the url, it adds the fp-x parameter twice, instead of adding the fp-y parameter for the y value.

I've fixed that in this PR.