### PR TITLE
Always return a string when building a path the ImageUrlBuilder

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -220,7 +220,14 @@ export class ImageUrlBuilder {
 
   // Gets the url based on the submitted parameters
   url() {
-    return urlForImage(this.options)
+    const url = urlForImage(this.options)
+    if (!url) {
+      // tslint:disable-next-line:no-console
+      console.warn(`Unable to resolve image URL with options: ${JSON.stringify(this.options)}`)
+      return ''
+    }
+
+    return url
   }
 
   // Alias for url()

--- a/test/builder.test.ts
+++ b/test/builder.test.ts
@@ -198,6 +198,15 @@ const cases = [
 ]
 
 describe('builder', () => {
+  beforeEach(() => {
+    jest.spyOn(global.console, "warn").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    // @ts-ignore: It's a mock, the method mockRestore should exist on it
+    global.console.warn.mockRestore()
+  })
+
   cases.forEach((testCase) => {
     test(testCase.name, () => {
       expect(testCase.url).toMatchSnapshot()
@@ -217,5 +226,13 @@ describe('builder', () => {
   test('should throw on invalid auto mode', () => {
     // @ts-ignore: Because we're throwing on invalids
     expect(() => urlFor.image(croppedImage()).auto('moo')).toThrowError(/Invalid auto mode "moo"/)
+  })
+
+  test('should warn on unparsable options', () => {
+    // @ts-ignore: Because we're are triggering the warning
+    const url = urlFor.image(null).url()
+
+    expect(url).toBe("")
+    expect(global.console.warn).toHaveBeenCalledWith(expect.stringContaining('Unable to resolve image URL with options'))
   })
 })


### PR DESCRIPTION
Hey sanity!

The function `urlForImage()` could return `null` or a string. This lead to an exported type:

```js
export declare class ImageUrlBuilder {
    // ...
    url(): string | null;
    toString(): string | null;
}
```

In a TS project, having the `string | null` type make the library hard to use:

```js
export const MyComponent = () => {
  const myFooPayload = useFoo()
  const imageUrlBuilder = useImageUrlBuilder()

   if (!myFooPayload) {
      return 'Loading';
  }

  return (
    <div>
      <MyOtherComponent 
          image={imageUrlBuilder(myFooPayload.image.url)} // Won't work if the component require the image props
          caption={myFooPayload.image.url.caption} 
      />
    </div>
  )
```

This lead to some bad DX to use the libraries. 

It also lead to a declared type "toString(): string | null". The "toString()" should always return a string (null is not the absence of a primitive type, like it could be for an object). 

This PR is here to try to solve there two points. 

Others solutions could be to change the behaviour of the `urlForImage` function to handle differently an invalid sources: throw and error, or return an empty string and show a warning.

I'm available for question and to continue the work on this PR 