### PR TITLE
[BREAKING] Throw error on invalid source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+All _notable_ changes will be documented in this file.
+
+## 1.0.0 - 2021-09-01
+
+### BREAKING
+
+- Throw error when passing invalid source instead of returning `null`

--- a/src/urlForImage.ts
+++ b/src/urlForImage.ts
@@ -33,14 +33,14 @@ export const SPEC_NAME_TO_URL_NAME_MAPPINGS = [
   ['pad', 'pad'],
 ]
 
-export default function urlForImage(options: ImageUrlBuilderOptions) {
+export default function urlForImage(options: ImageUrlBuilderOptions): string {
   let spec = {...(options || {})}
   const source = spec.source
   delete spec.source
 
   const image = parseSource(source)
   if (!image) {
-    return null
+    throw new Error(`Unable to resolve image URL from source (${JSON.stringify(source)})`)
   }
 
   const id = (image.asset as SanityReference)._ref || (image.asset as SanityAsset)._id || ''

--- a/test/urlForHotspotImage.test.ts
+++ b/test/urlForHotspotImage.test.ts
@@ -8,7 +8,14 @@ import {
   uncroppedImage,
 } from './fixtures'
 
-describe('urlForHotspotImage', () => {
+describe('urlForImage', () => {
+  test('should throw on invalid source', () => {
+    // @ts-ignore: Because we're throwing on invalids
+    expect(() => urlForImage({source: {}}).toString()).toThrowError(
+      'Unable to resolve image URL from source ({})'
+    )
+  })
+
   test('does not crop when no crop is required', () => {
     expect(
       urlForImage({source: uncroppedImage(), projectId: 'zp7mbokg', dataset: 'production'})


### PR DESCRIPTION
When passing an invalid source, for instance `null`, `undefined` or `{}`, the builder currently silently returns `null`. This is not very easy to debug/spot, and it also makes the typescript definitions weird (`toString()`/`url()` can always return `null`).

I suggest we start throwing errors in this case instead. Thoughts?

On a slight side note, this is a breaking change and this module is still on the 0.x range, so bumping its minor version should be enough - but should we bump it to 1.0 for clarity?