### PR TITLE
Patched baseUrl, set to parent when not in options

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -60,7 +60,7 @@ export class ImageUrlBuilder {
   }
 
   withOptions(options: Partial<ImageUrlBuilderOptionsWithAliases>) {
-    const baseUrl = options.baseUrl || ''
+    const baseUrl = options.baseUrl || (this.options || {}).baseUrl || ''
 
     const newOptions: {[key: string]: any} = {baseUrl}
     for (const key in options) {


### PR DESCRIPTION
Hi Sanity Team,

When playing with lists i found out that it was always showing the preview image from the cdn host and not from my development host. After some investigation I found, this issue:

- When_ using a custom host, the CDN is in some cases set to "" resulting in using https://cdn.sanity.io instead of the parent baseUrl._ 

The small fix below will the use **parent baseUrl** if baseUrl was not set in the options of ImageUrlBuilder.

```js
 withOptions(options: Partial<ImageUrlBuilderOptionsWithAliases>) {
    const baseUrl = options.baseUrl || (this.options || {}).baseUrl || ''
.......

```
