### PR TITLE
Fix Missing pad helper method on ImageUrlBuilder #29

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,7 @@ Ignore any specifications from the image record (i.e. crop and hotspot).
 ### `url()`, `toString()`
 
 Return the url as a string.
+
+### `pad(value)`
+
+Specify the number of pixels to pad the image.

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -179,7 +179,7 @@ export class ImageUrlBuilder {
     return this.withOptions({flipHorizontal: true})
   }
 
-  // Flip image verically
+  // Flip image vertically
   flipVertical() {
     return this.withOptions({flipVertical: true})
   }
@@ -216,6 +216,11 @@ export class ImageUrlBuilder {
     }
 
     return this.withOptions({auto: value})
+  }
+
+  // Specify the number of pixels to pad the image
+  pad(pad: number) {
+    return this.withOptions({pad})
   }
 
   // Gets the url based on the submitted parameters

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export type ImageUrlBuilderOptions = Partial<SanityProjectDetails> & {
   crop?: CropMode
   saturation?: number
   auto?: AutoMode
+  pad?: number
 }
 
 export type ImageUrlBuilderOptionsWithAliases = ImageUrlBuilderOptions & {

--- a/src/urlForImage.ts
+++ b/src/urlForImage.ts
@@ -30,6 +30,7 @@ export const SPEC_NAME_TO_URL_NAME_MAPPINGS = [
   ['saturation', 'sat'],
   ['auto', 'auto'],
   ['dpr', 'dpr'],
+  ['pad', 'pad'],
 ]
 
 export default function urlForImage(options: ImageUrlBuilderOptions) {

--- a/test/__snapshots__/builder.test.ts.snap
+++ b/test/__snapshots__/builder.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`builder all hotspot/crop-compatible params 1`] = `"rect=200,300,1600,2400&flip=hv&fm=png&dl=a.png&blur=50&sharp=7&invert=true&or=90&min-h=150&max-h=300&min-w=100&max-w=200&q=50&fit=crop&auto=format"`;
+exports[`builder all hotspot/crop-compatible params 1`] = `"rect=200,300,1600,2400&flip=hv&fm=png&dl=a.png&blur=50&sharp=7&invert=true&or=90&min-h=150&max-h=300&min-w=100&max-w=200&q=50&fit=crop&auto=format&pad=40"`;
 
-exports[`builder all params 1`] = `"rect=10,20,30,40&bg=bf1942&fp-x=10&fp-y=20&flip=hv&fm=png&dl=a.png&blur=50&invert=true&or=90&min-h=150&max-h=300&min-w=100&max-w=200&q=50&fit=crop&crop=center&auto=format"`;
+exports[`builder all params 1`] = `"rect=10,20,30,40&bg=bf1942&fp-x=10&fp-y=20&flip=hv&fm=png&dl=a.png&blur=50&invert=true&or=90&min-h=150&max-h=300&min-w=100&max-w=200&q=50&fit=crop&crop=center&auto=format&pad=40"`;
 
 exports[`builder automatic format 1`] = `"auto=format"`;
 
@@ -29,6 +29,8 @@ exports[`builder handles crop but no hotspot 1`] = `"https://cdn.sanity.io/image
 exports[`builder handles hotspot but no crop 1`] = `"https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg"`;
 
 exports[`builder handles materialized assets (GraphQL) 1`] = `"https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg"`;
+
+exports[`builder pad 1`] = `"pad=50"`;
 
 exports[`builder skips hotspot/crop if crop mode specified 1`] = `"https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg?w=100&h=80&crop=center"`;
 

--- a/test/builder.test.ts
+++ b/test/builder.test.ts
@@ -125,6 +125,11 @@ const cases = [
   },
 
   {
+    name: 'pad',
+    url: stripPath(urlFor.image(noHotspotImage()).pad(50).url()),
+  },
+
+  {
     name: 'automatic format',
     url: stripPath(urlFor.image(noHotspotImage()).auto('format').url()),
   },
@@ -165,6 +170,7 @@ const cases = [
         .flipHorizontal()
         .flipVertical()
         .fit('crop')
+	.pad(40)
         .url()
     ),
   },
@@ -192,6 +198,7 @@ const cases = [
         .flipVertical()
         .fit('crop')
         .crop('center')
+        .pad(40)
         .url()
     ),
   },


### PR DESCRIPTION
Updated the ImageUrlBuilder class to include a pad helper method. 

Updated unit test to test the new method. 

Fixes GitHub issue #29.