### PR TITLE
fix(url-for-image): Rect overflows image bounds

### DIFF
--- a/src/urlForImage.ts
+++ b/src/urlForImage.ts
@@ -150,13 +150,13 @@ function fit(
 
   if (cropAspectRatio > desiredAspectRatio) {
     // The crop is wider than the desired aspect ratio. That means we are cutting from the sides
-    const height = crop.height
-    const width = height * desiredAspectRatio
-    const top = crop.top
+    const height = Math.round(crop.height)
+    const width = Math.round(height * desiredAspectRatio)
+    const top = Math.max(0, Math.round(crop.top))
 
     // Center output horizontally over hotspot
-    const hotspotXCenter = (hotspot.right - hotspot.left) / 2 + hotspot.left
-    let left = hotspotXCenter - width / 2
+    const hotspotXCenter = Math.round((hotspot.right - hotspot.left) / 2 + hotspot.left)
+    let left = Math.max(0, Math.round(hotspotXCenter - width / 2))
 
     // Keep output within crop
     if (left < crop.left) {
@@ -164,25 +164,17 @@ function fit(
     } else if (left + width > crop.left + crop.width) {
       left = crop.left + crop.width - width
     }
-    // Math.round rounds up on .5, since both width and left are being rounded, there might be a .5 diff which can result in image width being out of bounds
-    // See https://codesandbox.io/s/boring-sound-8khon?file=/src/App.js
-    const leftDiff = Math.round(left) - left
 
-    cropRect = {
-      left: Math.round(left),
-      top: Math.round(top),
-      width: Math.round(width - leftDiff),
-      height: Math.round(height),
-    }
+    cropRect = {left, top, width, height}
   } else {
     // The crop is taller than the desired ratio, we are cutting from top and bottom
     const width = crop.width
-    const height = width / desiredAspectRatio
-    const left = crop.left
+    const height = Math.round(width / desiredAspectRatio)
+    const left = Math.max(0, Math.round(crop.left))
 
     // Center output vertically over hotspot
-    const hotspotYCenter = (hotspot.bottom - hotspot.top) / 2 + hotspot.top
-    let top = hotspotYCenter - height / 2
+    const hotspotYCenter = Math.round((hotspot.bottom - hotspot.top) / 2 + hotspot.top)
+    let top = Math.max(0, Math.round(hotspotYCenter - height / 2))
 
     // Keep output rect within crop
     if (top < crop.top) {
@@ -191,15 +183,7 @@ function fit(
       top = crop.top + crop.height - height
     }
 
-    // See L167
-    const topDiff = Math.round(top) - top
-
-    cropRect = {
-      left: Math.max(0, Math.floor(left)),
-      top: Math.max(0, Math.floor(top)),
-      width: Math.round(width),
-      height: Math.round(height - topDiff),
-    }
+    cropRect = {left, top, width, height}
   }
 
   return {

--- a/src/urlForImage.ts
+++ b/src/urlForImage.ts
@@ -164,11 +164,14 @@ function fit(
     } else if (left + width > crop.left + crop.width) {
       left = crop.left + crop.width - width
     }
+    // Math.round rounds up on .5, since both width and left are being rounded, there might be a .5 diff which can result in image width being out of bounds
+    // See https://codesandbox.io/s/boring-sound-8khon?file=/src/App.js
+    const leftDiff = Math.round(left) - left
 
     cropRect = {
       left: Math.round(left),
       top: Math.round(top),
-      width: Math.round(width),
+      width: Math.round(width - leftDiff),
       height: Math.round(height),
     }
   } else {
@@ -188,11 +191,14 @@ function fit(
       top = crop.top + crop.height - height
     }
 
+    // See L167
+    const topDiff = Math.round(top) - top
+
     cropRect = {
       left: Math.max(0, Math.floor(left)),
       top: Math.max(0, Math.floor(top)),
       width: Math.round(width),
-      height: Math.round(height),
+      height: Math.round(height - topDiff),
     }
   }
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -75,7 +75,7 @@ export function croppedImage() {
   }
 }
 
-export function croppedImageRounding() {
+export function croppedLandscapeImageRounding() {
   return {
     _type: 'image',
     asset: {
@@ -93,6 +93,28 @@ export function croppedImageRounding() {
       width: 0.48536873219336263,
       x: 0.5858922039336789,
       y: 0.3640740411931818,
+    },
+  }
+}
+
+export function croppedPortraitImageRounding() {
+  return {
+    _type: 'image',
+    asset: {
+      _ref: 'image-Tb9Ew8CXIwaY6R1kjMvI0uRR-2555x3833-jpg',
+      _type: 'reference',
+    },
+    crop: {
+      bottom: 0,
+      left: 0,
+      right: 0,
+      top: 0,
+    },
+    hotspot: {
+      width: 0.7281480823863636,
+      height: 0.48536873219336263,
+      x: 0.3640740411931818,
+      y: 0.5858922039336789,
     },
   }
 }

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -75,6 +75,28 @@ export function croppedImage() {
   }
 }
 
+export function croppedImageRounding() {
+  return {
+    _type: 'image',
+    asset: {
+      _ref: 'image-Tb9Ew8CXIwaY6R1kjMvI0uRR-3833x2555-jpg',
+      _type: 'reference',
+    },
+    crop: {
+      bottom: 0,
+      left: 0,
+      right: 0,
+      top: 0,
+    },
+    hotspot: {
+      height: 0.7281480823863636,
+      width: 0.48536873219336263,
+      x: 0.5858922039336789,
+      y: 0.3640740411931818,
+    },
+  }
+}
+
 export function noHotspotImage() {
   return {
     _type: 'image',

--- a/test/urlForHotspotImage.test.ts
+++ b/test/urlForHotspotImage.test.ts
@@ -1,7 +1,8 @@
 import urlForImage from '../src/urlForImage'
 import {
   croppedImage,
-  croppedImageRounding,
+  croppedLandscapeImageRounding,
+  croppedPortraitImageRounding,
   materializedAssetWithCrop,
   noHotspotImage,
   uncroppedImage,
@@ -163,16 +164,26 @@ describe('urlForHotspotImage', () => {
   test('gracefully handles rounding errors', () => {
     expect(
       urlForImage({
-        source: croppedImageRounding(),
+        source: croppedPortraitImageRounding(),
+        projectId: 'zp7mbokg',
+        dataset: 'production',
+        width: 400,
+        height: 600,
+      })
+    ).toBe(
+      'https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2555x3833.jpg?w=400&h=600'
+    )
+
+    expect(
+      urlForImage({
+        source: croppedLandscapeImageRounding(),
         projectId: 'zp7mbokg',
         dataset: 'production',
         width: 600,
         height: 400,
       })
     ).toBe(
-      'https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-3833x2555.jpg?rect=1,0,3832,2555&w=600&h=400'
+      'https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-3833x2555.jpg?w=600&h=400'
     )
-
-    // Todo: Find a test case it happens when the crop is not wider than the aspected ratio
   })
 })

--- a/test/urlForHotspotImage.test.ts
+++ b/test/urlForHotspotImage.test.ts
@@ -1,5 +1,11 @@
 import urlForImage from '../src/urlForImage'
-import {croppedImage, materializedAssetWithCrop, noHotspotImage, uncroppedImage} from './fixtures'
+import {
+  croppedImage,
+  croppedImageRounding,
+  materializedAssetWithCrop,
+  noHotspotImage,
+  uncroppedImage,
+} from './fixtures'
 
 describe('urlForHotspotImage', () => {
   test('does not crop when no crop is required', () => {
@@ -152,5 +158,21 @@ describe('urlForHotspotImage', () => {
     ).toBe(
       'https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg?rect=200,300,1600,2400&h=100'
     )
+  })
+
+  test('gracefully handles rounding errors', () => {
+    expect(
+      urlForImage({
+        source: croppedImageRounding(),
+        projectId: 'zp7mbokg',
+        dataset: 'production',
+        width: 600,
+        height: 400,
+      })
+    ).toBe(
+      'https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-3833x2555.jpg?rect=1,0,3832,2555&w=600&h=400'
+    )
+
+    // Todo: Find a test case it happens when the crop is not wider than the aspected ratio
   })
 })


### PR DESCRIPTION
Fixes issue where the desired aspect ratio is a half where the rect built is overflowing the image bounds.

See https://sanity-io-land.slack.com/archives/C9Z7RC3V1/p1623324362116100 & https://codesandbox.io/s/boring-sound-8khon?file=/src/App.js

I would ideally like to add more tests to this with more cases.

An alternative fix is:
```js

cropRect = {
  left: Math.ceil(left),
  top: Math.round(top),
  width: Math.floor(width),
  height: Math.round(height),
}
```

As it rounds the width down and left crop up.

Edit:

Released on npm as `@sanity/image-url@0.140.23-canary.0` 