### PR TITLE
feat: support @sanity/client v5

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,10 @@ export interface SanityClientLike {
   clientConfig: {dataset?: string; projectId?: string; apiHost?: string}
 }
 
+export type SanityModernClientLike = {
+  config(): {dataset?: string; projectId?: string; apiHost?: string}
+}
+
 export type SanityImageSource =
   | string // Image asset ID
   | SanityReference


### PR DESCRIPTION
With Sanity client v5 removing the `clientConfig` property, we need a way to get the configuration (project ID, dataset etc) from the new client. This PR adds a new asserter that uses the `config()` method to get this info. Theoretically it should also work for older client versions, but for backwards compatibility we also need to support the (somewhat edge case) scenario of someone simply passing a `{clientConfig: {...}}` object.