### PR TITLE
Chore: test on modern node versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 20
+          - 18
+          - 16
           - 14
           - 12
           - 10

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,9 @@ jobs:
           - 10
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - run: npm install
       - run: npm test


### PR DESCRIPTION
The Github Actions test matrix has become outdated. Arguably, versions 10, 12 and 14 could be removed because they are "end of life" releases (which I'm happy to do at your request) but at the very least it should include currently "active" LTS releases (16, 18, 20).

Source: https://nodejs.dev/en/about/releases/