### PR TITLE
Make format resettable

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -175,7 +175,7 @@ export class ImageUrlBuilder {
   }
 
   // Specify the image format of the image. 'jpg', 'pjpg', 'png', 'webp'
-  format(format: ImageFormat) {
+  format(format?: ImageFormat) {
     return this.withOptions({format})
   }
 


### PR DESCRIPTION
This pull request makes it possible to reset the format property.

The usecase for this is when you specify a default format for all images – like .webp – when you create your image builder.

```tsx
export const urlFor = (image) => imageBuilder.withOptions({ format: 'webp' }).image(image);
```

Now, if there's a place where you want to fetch the original format for instance, you want to reset that state. Passing in undefined will reset this property, returning the original format.

```tsx
const url = urlFor(image).format(undefined).url(); // will return the original format
```