### PR TITLE
feat(vanity): add support for vanity name in url

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ Return the url as a string.
 
 Specify the number of pixels to pad the image.
 
+### `vanityName(value)`
+ 
+Specify a vanity name for the image. This is useful for SEO purposes.
+
 ### Deprecated: `minWidth(pixels)`, `maxWidth(pixels)`, `minHeight(pixels)`, `maxHeight(pixels)`
 
 Specifies min/max dimensions when cropping.

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -247,6 +247,10 @@ export class ImageUrlBuilder {
     return this.withOptions({pad})
   }
 
+  vanityName(value: string) {
+    return this.withOptions({vanityName: value})
+  }
+
   // Gets the url based on the submitted parameters
   url() {
     return urlForImage(this.options)

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -247,6 +247,7 @@ export class ImageUrlBuilder {
     return this.withOptions({pad})
   }
 
+  // Vanity URL for more SEO friendly URLs
   vanityName(value: string) {
     return this.withOptions({vanityName: value})
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export type ImageUrlBuilderOptions = Partial<SanityProjectDetails> & {
   saturation?: number
   auto?: AutoMode
   pad?: number
+  vanityName?: string
 }
 
 export type ImageUrlBuilderOptionsWithAliases = ImageUrlBuilderOptions & {

--- a/src/urlForImage.ts
+++ b/src/urlForImage.ts
@@ -82,7 +82,7 @@ function specToImageUrl(spec: ImageUrlBuilderOptionsWithAsset) {
   const cdnUrl = (spec.baseUrl || 'https://cdn.sanity.io').replace(/\/+$/, '')
   const vanityStub = spec.vanityName ? `/${spec.vanityName}` : '' 
   const filename = `${spec.asset.id}-${spec.asset.width}x${spec.asset.height}.${spec.asset.format}${vanityStub}`
-  const baseUrl = `${cdnUrl}/images/${spec.projectId}/${spec.dataset}/${filename}`
+  const baseUrl = `${cdnUrl}/images/${spec.projectId}/${spec.dataset}/${filename}` 
 
   const params = []
 

--- a/src/urlForImage.ts
+++ b/src/urlForImage.ts
@@ -80,7 +80,8 @@ export default function urlForImage(options: ImageUrlBuilderOptions): string {
 // eslint-disable-next-line complexity
 function specToImageUrl(spec: ImageUrlBuilderOptionsWithAsset) {
   const cdnUrl = (spec.baseUrl || 'https://cdn.sanity.io').replace(/\/+$/, '')
-  const filename = `${spec.asset.id}-${spec.asset.width}x${spec.asset.height}.${spec.asset.format}`
+  const vanityStub = spec.vanityName ? `/${spec.vanityName}` : '' 
+  const filename = `${spec.asset.id}-${spec.asset.width}x${spec.asset.height}.${spec.asset.format}${vanityStub}`
   const baseUrl = `${cdnUrl}/images/${spec.projectId}/${spec.dataset}/${filename}`
 
   const params = []

--- a/test/__snapshots__/builder.test.ts.snap
+++ b/test/__snapshots__/builder.test.ts.snap
@@ -41,3 +41,5 @@ exports[`builder skips hotspot/crop if focal point specified 1`] = `"https://cdn
 exports[`builder sub zero top/left 1`] = `"w=1000&h=805"`;
 
 exports[`builder toString() aliases url() 1`] = `"https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg?w=100&h=80"`;
+
+exports[`builder vanity name 1`] = `"https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg/moo"`;

--- a/test/builder.test.ts
+++ b/test/builder.test.ts
@@ -145,6 +145,11 @@ const cases = [
   },
 
   {
+    name: 'vanity name',
+    url: urlFor.image(noHotspotImage()).vanityName('moo').url()
+  },
+
+  {
     name: 'sub zero top/left',
     url: stripPath(
       urlFor
@@ -175,7 +180,7 @@ const cases = [
         .flipHorizontal()
         .flipVertical()
         .fit('crop')
-        .pad(40)
+        .pad(40)  
         .url()
     ),
   },
@@ -203,7 +208,7 @@ const cases = [
         .flipVertical()
         .fit('crop')
         .crop('center')
-        .pad(40)
+        .pad(40) 
         .url()
     ),
   },
@@ -211,7 +216,7 @@ const cases = [
 
 describe('builder', () => {
   cases.forEach((testCase) => {
-    test(testCase.name, () => {
+    test(testCase.name, () => { 
       expect(testCase.url).toMatchSnapshot()
     })
   })

--- a/test/urlForHotspotImage.test.ts
+++ b/test/urlForHotspotImage.test.ts
@@ -193,31 +193,4 @@ describe('urlForImage', () => {
       'https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-3833x2555.jpg?w=600&h=400'
     )
   })
-
-  test('adds vanity name to url when specified, with params', () => {
-    expect(
-      urlForImage({
-        source: noHotspotImage(),
-        projectId: 'zp7mbokg',
-        dataset: 'production',
-        height: 100,
-        vanityName: 'my-image',
-      })
-    ).toBe(
-      'https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg/my-image?h=100'
-    )
-  })
-
-  test('adds vanity name to url when specified, without params', () => {
-    expect(
-      urlForImage({
-        source: noHotspotImage(),
-        projectId: 'zp7mbokg',
-        dataset: 'production',
-        vanityName: 'my-image',
-      })
-    ).toBe(
-      'https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg/my-image'
-    )
-  })
 })

--- a/test/urlForHotspotImage.test.ts
+++ b/test/urlForHotspotImage.test.ts
@@ -193,4 +193,31 @@ describe('urlForImage', () => {
       'https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-3833x2555.jpg?w=600&h=400'
     )
   })
+
+  test('adds vanity name to url when specified, with params', () => {
+    expect(
+      urlForImage({
+        source: noHotspotImage(),
+        projectId: 'zp7mbokg',
+        dataset: 'production',
+        height: 100,
+        vanityName: 'my-image',
+      })
+    ).toBe(
+      'https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg/my-image?h=100'
+    )
+  })
+
+  test('adds vanity name to url when specified, without params', () => {
+    expect(
+      urlForImage({
+        source: noHotspotImage(),
+        projectId: 'zp7mbokg',
+        dataset: 'production',
+        vanityName: 'my-image',
+      })
+    ).toBe(
+      'https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg/my-image'
+    )
+  })
 })


### PR DESCRIPTION
## Feature: Add method to builder to add vanity name 

### Description: 
Adds vanity name to the image builder by setting the vanityName() method 

### Reason:
Clear and descriptive file names are good for SEO purposes. Seemed useful to add to this package so you don't need extra logic to add it yourself.

Related issue: https://github.com/sanity-io/image-url/issues/40