### PR TITLE
feat: add placeholder object for when image is being uploaded

### DIFF
--- a/src/parseSource.ts
+++ b/src/parseSource.ts
@@ -44,7 +44,8 @@ export default function parseSource(source?: SanityImageSource) {
     // This allows the UI to continue rendering while the upload completes
     return {
       asset: {
-        _ref: 'image-placeholder-1x1-png', // Placeholder asset reference
+        // Placeholder asset reference that follows Sanity's asset reference format
+        _ref: 'image-placeholder-0x0-png',
       },
       crop: {
         left: 0,
@@ -53,10 +54,10 @@ export default function parseSource(source?: SanityImageSource) {
         right: 0,
       },
       hotspot: {
-        x: 0.5,
-        y: 0.5,
-        height: 1.0,
-        width: 1.0,
+        x: 0,
+        y: 0,
+        height: 0,
+        width: 0,
       },
     }
   }

--- a/src/parseSource.ts
+++ b/src/parseSource.ts
@@ -21,11 +21,44 @@ const isAssetStub = (src: SanityImageSource): src is SanityImageWithAssetStub =>
   return source && source.asset ? typeof source.asset.url === 'string' : false
 }
 
+// Detect in-progress uploads (has upload key but no complete asset reference)
+const isInProgressUpload = (src: SanityImageSource): boolean => {
+  if (typeof src === 'object' && src !== null) {
+    const obj = src as any
+    // Check if it has an upload key (indicating in-progress upload)
+    return obj._upload && (!obj.asset || !obj.asset._ref)
+  }
+  return false
+}
+
 // Convert an asset-id, asset or image to an image record suitable for processing
 // eslint-disable-next-line complexity
 export default function parseSource(source?: SanityImageSource) {
   if (!source) {
     return null
+  }
+
+  // Handle in-progress uploads by returning a default image object
+  if (isInProgressUpload(source)) {
+    // Return a default image object that won't crash the render cycle
+    // This allows the UI to continue rendering while the upload completes
+    return {
+      asset: {
+        _ref: 'image-placeholder-1x1-png', // Placeholder asset reference
+      },
+      crop: {
+        left: 0,
+        top: 0,
+        bottom: 0,
+        right: 0,
+      },
+      hotspot: {
+        x: 0.5,
+        y: 0.5,
+        height: 1.0,
+        width: 1.0,
+      },
+    }
   }
 
   let image: SanityImageObject

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -157,3 +157,15 @@ export function assetDocument() {
     url: 'https://cdn.sanity.io/images/ppsg7ml5/test/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg',
   }
 }
+
+export function inProgressUpload() {
+  return {
+    _type: 'image',
+    _upload: {
+      _type: 'sanity.fileAsset',
+      assetId: 'upload-123',
+      // No asset reference yet - upload is in progress
+    },
+    // Missing asset reference
+  }
+}

--- a/test/parseSource.test.ts
+++ b/test/parseSource.test.ts
@@ -7,6 +7,7 @@ import {
   imageWithNoCropSpecified,
   materializedAssetWithCrop,
   noHotspotImage,
+  inProgressUpload,
 } from './fixtures'
 
 function compareParsedSource(
@@ -114,5 +115,28 @@ describe('parseSource', () => {
         },
       }
     `)
+  })
+
+  test('handles in-progress uploads gracefully', () => {
+    const parsedSource = parseSource(inProgressUpload())
+    // Should return a default image object instead of null
+    expect(parsedSource).not.toBeNull()
+    expect(parsedSource).toMatchObject({
+      asset: {
+        _ref: 'image-placeholder-1x1-png',
+      },
+      crop: {
+        left: 0,
+        top: 0,
+        bottom: 0,
+        right: 0,
+      },
+      hotspot: {
+        x: 0.5,
+        y: 0.5,
+        height: 1.0,
+        width: 1.0,
+      },
+    })
   })
 })

--- a/test/parseSource.test.ts
+++ b/test/parseSource.test.ts
@@ -123,7 +123,7 @@ describe('parseSource', () => {
     expect(parsedSource).not.toBeNull()
     expect(parsedSource).toMatchObject({
       asset: {
-        _ref: 'image-placeholder-1x1-png',
+        _ref: 'image-placeholder-0x0-png',
       },
       crop: {
         left: 0,
@@ -132,10 +132,10 @@ describe('parseSource', () => {
         right: 0,
       },
       hotspot: {
-        x: 0.5,
-        y: 0.5,
-        height: 1.0,
-        width: 1.0,
+        x: 0,
+        y: 0,
+        height: 0,
+        width: 0,
       },
     })
   })

--- a/test/urlForHotspotImage.test.ts
+++ b/test/urlForHotspotImage.test.ts
@@ -6,6 +6,7 @@ import {
   materializedAssetWithCrop,
   noHotspotImage,
   uncroppedImage,
+  inProgressUpload,
 } from './fixtures'
 
 describe('urlForImage', () => {
@@ -14,6 +15,27 @@ describe('urlForImage', () => {
     expect(() => urlForImage({source: {}}).toString()).toThrowError(
       'Unable to resolve image URL from source ({})'
     )
+  })
+
+  test('handles in-progress uploads gracefully without throwing', () => {
+    // Should not throw an error for in-progress uploads
+    expect(() => 
+      urlForImage({
+        source: inProgressUpload(),
+        projectId: 'zp7mbokg',
+        dataset: 'production'
+      })
+    ).not.toThrow()
+    
+    // Should return a valid URL (even if it's a placeholder)
+    const url = urlForImage({
+      source: inProgressUpload(),
+      projectId: 'zp7mbokg',
+      dataset: 'production'
+    })
+    expect(url).toContain('cdn.sanity.io')
+    expect(url).toContain('zp7mbokg')
+    expect(url).toContain('production')
   })
 
   test('does not crop when no crop is required', () => {


### PR DESCRIPTION
### Description

Added a fall back value for when uploads are still in progress instead of throwing an unhandled error when trying to access methods before images are ready. This was requested as part of the maintenance rotation

https://github.com/user-attachments/assets/2dbcec5b-5857-494f-bc52-859661b8caa2


### What to review

Code added.
Also, this technically is a breaking change in expectations since folks might have have fall backs when errors were thrown. I added it as a feat, but let me know if I should add any indicator of breaking change - I thought it wouldn't be necessary

### Testing

New tests have been added as well as manual testing with the test studio (the only way I got that warning was copy pasting the this whole repo into the monorepo temporarily)
