### PR TITLE
refactor: when still uploading return a placeholder image via dataurl

### DIFF
--- a/src/parseSource.ts
+++ b/src/parseSource.ts
@@ -22,7 +22,7 @@ const isAssetStub = (src: SanityImageSource): src is SanityImageWithAssetStub =>
 }
 
 // Detect in-progress uploads (has upload key but no complete asset reference)
-const isInProgressUpload = (src: SanityImageSource): boolean => {
+export const isInProgressUpload = (src: SanityImageSource): boolean => {
   if (typeof src === 'object' && src !== null) {
     const obj = src as any
     // Check if it has an upload key (indicating in-progress upload)
@@ -36,30 +36,6 @@ const isInProgressUpload = (src: SanityImageSource): boolean => {
 export default function parseSource(source?: SanityImageSource) {
   if (!source) {
     return null
-  }
-
-  // Handle in-progress uploads by returning a default image object
-  if (isInProgressUpload(source)) {
-    // Return a default image object that won't crash the render cycle
-    // This allows the UI to continue rendering while the upload completes
-    return {
-      asset: {
-        // Placeholder asset reference that follows Sanity's asset reference format
-        _ref: 'image-placeholder-0x0-png',
-      },
-      crop: {
-        left: 0,
-        top: 0,
-        bottom: 0,
-        right: 0,
-      },
-      hotspot: {
-        x: 0,
-        y: 0,
-        height: 0,
-        width: 0,
-      },
-    }
   }
 
   let image: SanityImageObject

--- a/src/urlForImage.ts
+++ b/src/urlForImage.ts
@@ -1,5 +1,5 @@
 import parseAssetId from './parseAssetId'
-import parseSource from './parseSource'
+import parseSource, {isInProgressUpload} from './parseSource'
 import {
   CropSpec,
   HotspotSpec,
@@ -41,6 +41,11 @@ export default function urlForImage(options: ImageUrlBuilderOptions): string {
 
   const image = parseSource(source)
   if (!image) {
+    if (source && isInProgressUpload(source)) {
+      // This is a placeholder image that will be replaced with the actual image when the upload is complete
+      // This is a 0x0 transparent PNG image
+      return 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8HwQACfsD/QNViZkAAAAASUVORK5CYII='
+    }
     throw new Error(`Unable to resolve image URL from source (${JSON.stringify(source)})`)
   }
 

--- a/test/parseSource.test.ts
+++ b/test/parseSource.test.ts
@@ -116,27 +116,4 @@ describe('parseSource', () => {
       }
     `)
   })
-
-  test('handles in-progress uploads gracefully', () => {
-    const parsedSource = parseSource(inProgressUpload())
-    // Should return a default image object instead of null
-    expect(parsedSource).not.toBeNull()
-    expect(parsedSource).toMatchObject({
-      asset: {
-        _ref: 'image-placeholder-0x0-png',
-      },
-      crop: {
-        left: 0,
-        top: 0,
-        bottom: 0,
-        right: 0,
-      },
-      hotspot: {
-        x: 0,
-        y: 0,
-        height: 0,
-        width: 0,
-      },
-    })
-  })
 })

--- a/test/urlForHotspotImage.test.ts
+++ b/test/urlForHotspotImage.test.ts
@@ -33,9 +33,9 @@ describe('urlForImage', () => {
       projectId: 'zp7mbokg',
       dataset: 'production',
     })
-    expect(url).toContain('cdn.sanity.io')
-    expect(url).toContain('zp7mbokg')
-    expect(url).toContain('production')
+    expect(url).toContain(
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8HwQACfsD/QNViZkAAAAASUVORK5CYII='
+    )
   })
 
   test('does not crop when no crop is required', () => {


### PR DESCRIPTION
### Description

It's what it says on the tin, suggested by Espen and Cody.
This dataurl will return a 0x0 transparent placeholder.

### What to review

Does this make sense?

### Testing

Manually tested it in the studio, updated the tests, everything should pass
