### PR TITLE
fix: read dataset and canvas resources

### DIFF
--- a/.changeset/metal-pens-wish.md
+++ b/.changeset/metal-pens-wish.md
@@ -1,0 +1,5 @@
+---
+'@sanity/image-url': patch
+---
+
+Ensures that passing a `canvas` or `dataset` resource will create a valid URL

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -48,6 +48,23 @@ function clientConfigToOptions(config: SanityClientConfig): ImageUrlBuilderOptio
     return {...baseOptions, mediaLibraryId: resource.id}
   }
 
+  if (resource?.type === 'canvas') {
+    if (typeof resource.id !== 'string' || resource.id.length === 0) {
+      throw new Error('Canvas clients must include an id in "resource"')
+    }
+
+    return {...baseOptions, canvasId: resource.id}
+  }
+
+  if (resource?.type === 'dataset') {
+    if (typeof resource.id !== 'string' || resource.id.length === 0) {
+      throw new Error('Dataset clients must include an id in "resource"')
+    }
+
+    const [resourceProjectId, resourceDataset] = resource.id.split('.')
+    return {...baseOptions, projectId: resourceProjectId, dataset: resourceDataset}
+  }
+
   return {...baseOptions, projectId, dataset}
 }
 
@@ -170,6 +187,7 @@ export class ImageUrlBuilderImpl implements ImageUrlBuilder {
     delete preservedOptions.projectId
     delete preservedOptions.dataset
     delete preservedOptions.mediaLibraryId
+    delete preservedOptions.canvasId
 
     return new ImageUrlBuilderImpl(null, {...newOptions, ...preservedOptions}) as this
   }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -62,6 +62,12 @@ function clientConfigToOptions(config: SanityClientConfig): ImageUrlBuilderOptio
     }
 
     const [resourceProjectId, resourceDataset] = resource.id.split('.')
+    if (!resourceProjectId || !resourceDataset) {
+      throw new Error(
+        'Dataset resource id must be in the format "projectId.dataset", got: ' + resource.id
+      )
+    }
+
     return {...baseOptions, projectId: resourceProjectId, dataset: resourceDataset}
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@
 export type ImageUrlBuilderOptions = Partial<SanityProjectDetails> & {
   baseUrl?: string
   mediaLibraryId?: string
+  canvasId?: string
   source?: SanityImageSource
   bg?: string
   dpr?: number
@@ -95,7 +96,7 @@ export type Orientation = 0 | 90 | 180 | 270
  * @internal
  */
 export interface SanityClientConfigResource {
-  type: 'media-library' | (string & {})
+  type: 'media-library' | 'canvas' | 'dataset' | (string & {})
   id: string
 }
 

--- a/src/urlForImage.ts
+++ b/src/urlForImage.ts
@@ -91,9 +91,14 @@ function specToImageUrl(spec: ImageUrlBuilderOptionsWithAsset) {
   const cdnUrl = (spec.baseUrl || 'https://cdn.sanity.io').replace(/\/+$/, '')
   const vanityStub = spec.vanityName ? `/${spec.vanityName}` : ''
   const filename = `${spec.asset.id}-${spec.asset.width}x${spec.asset.height}.${spec.asset.format}${vanityStub}`
-  const baseUrl = spec.mediaLibraryId
-    ? `${cdnUrl}/media-libraries/${spec.mediaLibraryId}/images/${filename}`
-    : `${cdnUrl}/images/${spec.projectId}/${spec.dataset}/${filename}`
+  let baseUrl: string
+  if (spec.mediaLibraryId) {
+    baseUrl = `${cdnUrl}/media-libraries/${spec.mediaLibraryId}/images/${filename}`
+  } else if (spec.canvasId) {
+    baseUrl = `${cdnUrl}/images/canvases/${spec.canvasId}/${filename}`
+  } else {
+    baseUrl = `${cdnUrl}/images/${spec.projectId}/${spec.dataset}/${filename}`
+  }
 
   const params: string[] = []
 

--- a/test/fromClient.test.ts
+++ b/test/fromClient.test.ts
@@ -128,4 +128,56 @@ describe('init from client', () => {
       'Media library clients must include an id in "resource"'
     )
   })
+
+  test('can get canvas base url from client config', () => {
+    const client = {
+      clientConfig: {
+        apiHost: 'https://api.sanity.io',
+        resource: {type: 'canvas' as const, id: 'cag5gSK37IGV'},
+      },
+    }
+
+    expect(createImageUrlBuilder(client).image('image-abc123-200x200-png').toString()).toBe(
+      'https://cdn.sanity.io/images/canvases/cag5gSK37IGV/abc123-200x200.png'
+    )
+  })
+
+  test('throws error when canvas resource is missing id', () => {
+    const client = {
+      clientConfig: {
+        apiHost: 'https://api.sanity.io',
+        resource: {type: 'canvas' as const, id: ''},
+      },
+    }
+
+    expect(() => createImageUrlBuilder(client)).toThrow(
+      'Canvas clients must include an id in "resource"'
+    )
+  })
+
+  test('dataset resource type derives projectId and dataset from resource id', () => {
+    const client = {
+      clientConfig: {
+        apiHost: 'https://api.sanity.io',
+        resource: {type: 'dataset' as const, id: 'abc123.foo'},
+      },
+    }
+
+    expect(createImageUrlBuilder(client).image('image-abc123-200x200-png').toString()).toBe(
+      'https://cdn.sanity.io/images/abc123/foo/abc123-200x200.png'
+    )
+  })
+
+  test('throws error when dataset resource is missing id', () => {
+    const client = {
+      clientConfig: {
+        apiHost: 'https://api.sanity.io',
+        resource: {type: 'dataset' as const, id: ''},
+      },
+    }
+
+    expect(() => createImageUrlBuilder(client)).toThrow(
+      'Dataset clients must include an id in "resource"'
+    )
+  })
 })

--- a/test/fromClient.test.ts
+++ b/test/fromClient.test.ts
@@ -155,6 +155,19 @@ describe('init from client', () => {
     )
   })
 
+  test('throws error when dataset resource id is malformed', () => {
+    const client = {
+      clientConfig: {
+        apiHost: 'https://api.sanity.io',
+        resource: {type: 'dataset' as const, id: 'nodot'},
+      },
+    }
+
+    expect(() => createImageUrlBuilder(client)).toThrow(
+      'Dataset resource id must be in the format "projectId.dataset", got: nodot'
+    )
+  })
+
   test('dataset resource type derives projectId and dataset from resource id', () => {
     const client = {
       clientConfig: {


### PR DESCRIPTION
### Description
As the SDK moves to using global resources for everything, it would be great for consistency if we pass the same client around to our image builder as well. This PR extends the existing Media Library logic for resources to dataset and canvas resources.

### What to review
This should hopefully be pretty straightforward. Are there any places I failed to update?

### Testing
Tests were added.